### PR TITLE
feat: add only build support to cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ async function main() {
 main()
 ```
 
-#### Example: Build Contracts
+#### Example: Build Contract using CLI
 
 To Build contracts and produce single bundle lua file, take a look at below provided commands
 
@@ -246,6 +246,58 @@ Build contract and save to specific directory:
 ```sh
 aod src/process.lua -n my-process --only-build --build-output <PATH>
 aod src/process.lua -n my-process --only-build --build-output ./dist
+```
+
+#### Example: Build Contracts using Config
+
+To Build contracts using config, take a look at below provided example
+
+Here is an example using a deployment configuration:
+
+```ts
+// aod.config.ts
+import { defineConfig } from 'ao-deploy'
+
+const wallet = 'wallet.json'
+const luaPath = './?.lua;./src/?.lua'
+
+const config = defineConfig({
+  contract_1: {
+    luaPath,
+    name: `contract-1`,
+    contractPath: 'contract-1.lua',
+    wallet,
+    outDir: './dist',
+  },
+  contract_2: {
+    luaPath,
+    name: `contract-2`,
+    contractPath: 'contract-2.lua',
+    wallet,
+    outDir: './dist',
+  },
+  contract_3: {
+    luaPath,
+    name: `contract-3`,
+    contractPath: 'contract-3.lua',
+    wallet,
+    outDir: './dist',
+  }
+})
+
+export default config
+```
+
+Build all specified contracts:
+
+```sh
+ao-deploy aod.config.ts --only-build
+```
+
+build specific contracts:
+
+```sh
+ao-deploy aod.config.ts --deploy=contract_1,contract_3 --only-build
 ```
 
 ## Author

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Options:
   -c, --cron [interval]         Cron interval for the process (e.g. 1-minute, 5-minutes).
   -t, --tags [tags...]          Additional tags for spawning the process.
   -p, --process-id [processId]  Specify process Id of existing process.
+  --only-build                  Only bundle modular lua project into single file stored at process-dist.
+  --build-output [path]         Used with --only-build to save single bundle file at provided path.
   --concurrency [limit]         Concurrency limit for deploying multiple processes. (default: "5")
   --retry-count [count]         Number of retries for deploying contract. (default: "10")
   --retry-delay [delay]         Delay between retries in milliseconds. (default: "3000")
@@ -227,6 +229,23 @@ async function main() {
 }
 
 main()
+```
+
+#### Example: Build Contracts
+
+To Build contracts and produce single bundle lua file, take a look at below provided commands
+
+Build contract and save to default(`process-dist`) directory:
+
+```sh
+aod src/process.lua -n my-process --only-build
+```
+
+Build contract and save to specific directory:
+
+```sh
+aod src/process.lua -n my-process --only-build --build-output <PATH>
+aod src/process.lua -n my-process --only-build --build-output ./dist
 ```
 
 ## Author

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ao-deploy-beta",
   "type": "module",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "packageManager": "pnpm@8.15.3",
   "description": "A package for deploying AO contracts",
   "author": "Pawan Paudel <pawanpaudel93@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ao-deploy-beta",
   "type": "module",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "packageManager": "pnpm@8.15.3",
   "description": "A package for deploying AO contracts",
   "author": "Pawan Paudel <pawanpaudel93@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "ao-deploy",
+  "name": "ao-deploy-beta",
   "type": "module",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "packageManager": "pnpm@8.15.3",
   "description": "A package for deploying AO contracts",
   "author": "Pawan Paudel <pawanpaudel93@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ao-deploy-beta",
   "type": "module",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "packageManager": "pnpm@8.15.3",
   "description": "A package for deploying AO contracts",
   "author": "Pawan Paudel <pawanpaudel93@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ao-deploy-beta",
   "type": "module",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "packageManager": "pnpm@8.15.3",
   "description": "A package for deploying AO contracts",
   "author": "Pawan Paudel <pawanpaudel93@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "ao-deploy-beta",
+  "name": "ao-deploy",
   "type": "module",
-  "version": "0.2.7",
+  "version": "0.2.2",
   "packageManager": "pnpm@8.15.3",
   "description": "A package for deploying AO contracts",
   "author": "Pawan Paudel <pawanpaudel93@gmail.com>",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -186,7 +186,7 @@ async function buildHandler() {
       const bundlingConfigs = deployConfigs.map(config => ({
         name: config.name || 'bundle',
         contractPath: config.contractPath,
-        outDir: config.outDir || './dist',
+        outDir: config.outDir || './process-dist',
       }))
       const results = await loadAndBundleContracts(bundlingConfigs, concurrency)
 
@@ -204,7 +204,7 @@ async function buildHandler() {
 
       const totalCount = bundlingConfigs.length
       const successCount = results.length
-      Logger.log(packageJson.name, `Bundling Status: ${chalk.green(`${successCount}/${totalCount}`)} successful deployments.`, true)
+      Logger.log(packageJson.name, `Successful builds: ${chalk.green(`${successCount}/${totalCount}`)} successful deployments.`, true)
     }
   }
   catch (error: any) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,8 +8,11 @@ import chalk from 'chalk'
 import { Command } from 'commander'
 import { deployContract, deployContracts } from './lib/deploy'
 import { ConfigManager } from './lib/config'
-import type { DeployResult, Tag } from './types'
+import type { BundleResult, DeployResult, Tag } from './types'
 import { Logger } from './lib/logger'
+import { BuildError, DeployError } from './lib/error'
+import { loadAndBundleContracts } from './lib/loader'
+import { clearBuildOutDir } from './lib/utils'
 
 const PKG_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '../')
 
@@ -53,6 +56,20 @@ function logDeploymentDetails(result: DeployResult) {
   logger.log(`Deployment Message: ${messageUrl}`)
 }
 
+function logBundleDetails(result: BundleResult) {
+  const { name, outDir, size, configName } = result
+  const generated = chalk.green(`${name}.lua has been generated at ${outDir}`)
+  const bundleSize = chalk.green(`Bundle size is bytes: ${size}`)
+  const logger = Logger.init(configName)
+
+  console.log('')
+
+  logger.log(`Bundling Service: ${generated}`)
+  logger.log(`Bundling Service: ${bundleSize}`)
+
+  logger.log(`Bundling complete! ✨`)
+}
+
 const program = new Command()
 const packageJson = getPackageJson()
 program
@@ -69,6 +86,8 @@ program
   .option('-c, --cron [interval]', 'Cron interval for the process (e.g. 1-minute, 5-minutes).')
   .option('-t, --tags [tags...]', 'Additional tags for spawning the process.')
   .option('-p, --process-id [processId]', 'Specify process Id of an existing process.')
+  .option('--only-build', 'Only bundles modular ao process code into single bundle file and saves at provided location.')
+  .option('--build-output [out path for bundle file]', 'Specify process Id of an existing process.')
   .option('--concurrency [limit]', 'Concurrency limit for deploying multiple processes.', '5')
   .option('--retry-count [count]', 'Number of retries for deploying contract.', '10')
   .option('--retry-delay [delay]', 'Delay between retries in milliseconds.', '3000')
@@ -77,11 +96,14 @@ program.parse(process.argv)
 
 const options = program.opts()
 const contractOrConfigPath = program.args[0]
+const isContractPath = contractOrConfigPath.endsWith('.lua')
+const isOnlyBuild = options.onlyBuild
+const buildOutput = options.buildOutput || './process-dist'
 
-;(async () => {
+async function deploymentHandler() {
   try {
     Logger.log(packageJson.name, 'Deploying...', false, true)
-    if (contractOrConfigPath.endsWith('.lua')) {
+    if (isContractPath) {
       const tags: Tag[] = Array.isArray(options.tags)
         ? options.tags.reduce<Tag[]>((accumulator, tag) => {
           if (tag && tag.includes(':')) {
@@ -134,9 +156,82 @@ const contractOrConfigPath = program.args[0]
     }
   }
   catch (error: any) {
+    throw new DeployError(error?.message ?? 'Failed to deploy contract!')
+  }
+}
+
+async function buildHandler() {
+  try {
+    await clearBuildOutDir(buildOutput)
+    Logger.log(packageJson.name, 'Bundling...', false, true)
+
+    const name = options.name || 'bundle'
+
+    if (isContractPath) {
+      const [result] = await loadAndBundleContracts([{ contractPath: contractOrConfigPath, name, outDir: buildOutput }], 1)
+
+      if (result && result.status === 'fulfilled') {
+        logBundleDetails(result.value)
+      }
+      else {
+        Logger.error(name, 'Failed to bundle contract!', true)
+        Logger.error(name, result.reason)
+      }
+    }
+    else {
+      const configManager = new ConfigManager(contractOrConfigPath)
+      const deployConfigs = configManager.getDeployConfigs(options.deploy)
+      const concurrency = parseToInt(options.concurrency, 5)
+
+      const bundlingConfigs = deployConfigs.map(config => ({
+        name: config.name || 'bundle',
+        contractPath: config.contractPath,
+        outDir: config.outDir || './dist',
+      }))
+      const results = await loadAndBundleContracts(bundlingConfigs, concurrency)
+
+      results.forEach((result, idx) => {
+        const configName = deployConfigs[idx].configName!
+
+        if (result.status === 'fulfilled') {
+          logBundleDetails(result.value)
+        }
+        else {
+          Logger.error(configName, 'Failed to bundle contract!', true)
+          Logger.error(configName, result.reason)
+        }
+      })
+
+      const totalCount = bundlingConfigs.length
+      const successCount = results.length
+      Logger.log(packageJson.name, `Bundling Status: ${chalk.green(`${successCount}/${totalCount}`)} successful deployments.`, true)
+    }
+  }
+  catch (error: any) {
+    throw new BuildError(error?.message ?? 'Failed to bundle contract!')
+  }
+}
+
+;(async () => {
+  try {
+    if (isOnlyBuild) {
+      await buildHandler()
+    }
+    else {
+      await deploymentHandler()
+    }
+  }
+  catch (error: any) {
     const logger = Logger.init(packageJson.name)
-    logger.error(`Deployment failed!`, true)
-    logger.error(error?.message ?? 'Failed to deploy contract!')
+
+    if (error instanceof DeployError) {
+      logger.error(`Deployment failed!`, true)
+    }
+    if (error instanceof BuildError) {
+      logger.error(`Build failed!`, true)
+    }
+
+    logger.error(error?.message)
     process.exit(1)
   }
 })()

--- a/src/lib/deploy.ts
+++ b/src/lib/deploy.ts
@@ -124,6 +124,7 @@ export class DeploymentsManager {
     const loader = new LuaProjectLoader(configName, luaPath)
     const contractSrc = await loader.loadContract(contractPath)
 
+    logger.log(`Deploying: ${contractPath}`, false, true)
     // Load contract to process
     const messageId = await retryWithDelay(
       async () =>

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -1,0 +1,2 @@
+export class BuildError extends Error {}
+export class DeployError extends Error {}

--- a/src/lib/loader.ts
+++ b/src/lib/loader.ts
@@ -200,10 +200,12 @@ export class LuaProjectLoader {
 }
 
 export async function loadAndBundleContracts(configs: BundlingConfig[], concurrency: number = 5): Promise<PromiseSettledResult<BundleResult>[]> {
-  const loader = new LuaProjectLoader('bundle')
-
   const limit = pLimit(concurrency)
-  const promises = configs.map(config => limit(() => loader.loadAndBundleContract(config)))
+  const promises = configs.map(config => limit(() => {
+    const loader = new LuaProjectLoader(config.name)
+
+    return loader.loadAndBundleContract(config)
+  }))
 
   return await Promise.allSettled(promises)
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,7 @@
+import path from 'node:path'
+import process from 'node:process'
+import { writeFile } from 'node:fs/promises'
+import { existsSync, mkdirSync, rmSync } from 'node:fs'
 import Arweave from 'arweave'
 import Ardb from 'ardb'
 
@@ -48,4 +52,34 @@ export async function retryWithDelay<T>(
   }
 
   return attempt()
+}
+
+export async function writeFileToProjectDir(data: string, outDir: string, fileName: string) {
+  try {
+    const fullPath = path.join(process.cwd(), `${outDir}/${fileName}.lua`)
+    const dirName = path.dirname(fullPath)
+    if (!existsSync(dirName)) {
+      mkdirSync(dirName)
+    }
+    await writeFile(fullPath, data)
+  }
+  catch (error) {
+    throw new Error(`Failed to write bundle to ${outDir}`)
+  }
+}
+
+export async function clearBuildOutDir(outDir: string) {
+  try {
+    const fullPath = path.join(process.cwd(), `${outDir}`)
+    const dirName = path.dirname(fullPath)
+
+    if (!existsSync(dirName)) {
+      return true
+    }
+
+    rmSync(outDir, { recursive: true, force: true })
+  }
+  catch (error) {
+    throw new Error(`Failed to clear ${outDir}`)
+  }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -70,6 +70,10 @@ export interface DeployConfig {
    * Process Id of an existing process
    */
   processId?: string
+  /**
+   * Output directory of bundle
+   */
+  outDir?: string
 }
 
 export type Config = Record<ConfigName, DeployConfig>
@@ -80,6 +84,19 @@ export interface DeployResult {
   messageId: string
   processId: string
   isNewProcess: boolean
+}
+
+export interface BundleResult {
+  name: string
+  configName: string
+  outDir: string
+  size: number
+}
+
+export interface BundlingConfig {
+  name: string
+  contractPath: string
+  outDir: string
 }
 
 export interface Module { name: string, path: string, content?: string, dependencies?: Set<string> }


### PR DESCRIPTION
## Summary
This feature adds support for two new flags as cli options, `--only-build` and `--build-output`. 

if `--only-build` flag is provided then process wont be deployed but instead contractSrc will be written to `process-dist` folder in project directory.
if `--build-output <PATH>` flag is provided then process src will be written to provided PATH. 

This PR also handles the case of auto clearing PATH or default folder before producing builds. It also keeps in mind if user uses Config driven approach, it uses limit to concurrently build projects.

try with demo package `npm i ao-deploy-beta`