### PR TITLE
Add force-spawn option to always spawn new process

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Options:
   --retry-delay [delay]         Delay between retries in milliseconds. (default: 3000)
   --minify                      Reduce the size of the contract before deployment. (default: false)
   --on-boot                     Load contract when process is spawned. (default: false)
+  --force-spawn                 Force spawning a new process without checking for existing ones. (default: false)
   -h, --help                    display help for command
 ```
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -153,7 +153,11 @@ program
     3000
   )
   .option("--minify", "Reduce the size of the contract before deployment.")
-  .option("--on-boot", "Load contract when process is spawned.");
+  .option("--on-boot", "Load contract when process is spawned.")
+  .option(
+    "--force-spawn",
+    "Force spawning a new process without checking for existing ones."
+  );
 
 program.parse(process.argv);
 
@@ -199,7 +203,8 @@ async function deploymentHandler() {
           muUrl: options.muUrl
         },
         minify: options.minify,
-        onBoot: options.onBoot
+        onBoot: options.onBoot,
+        forceSpawn: options.forceSpawn
       });
       logDeploymentDetails(result);
     } else {

--- a/src/lib/deploy.ts
+++ b/src/lib/deploy.ts
@@ -133,7 +133,8 @@ export class DeploymentsManager {
     minify,
     contractTransformer,
     onBoot,
-    silent = false
+    silent = false,
+    forceSpawn = false
   }: DeployConfig): Promise<DeployResult> {
     name = name || "default";
     configName = configName || name;
@@ -159,16 +160,20 @@ export class DeploymentsManager {
     // Initialize the AO instance with validated URLs
     const aoInstance = this.#getAoInstance(services);
 
-    if (!processId || (processId && !isArweaveAddress(processId))) {
+    let isNewProcess = forceSpawn;
+
+    if (
+      !forceSpawn &&
+      (!processId || (processId && !isArweaveAddress(processId)))
+    ) {
       processId = await this.#findProcess(
         name,
         owner,
         retry,
         services.gatewayUrl!
       );
+      isNewProcess = !processId;
     }
-
-    const isNewProcess = !processId;
 
     const loader = new LuaProjectLoader(configName, luaPath, silent);
     let contractSrc = await loader.loadContract(contractPath);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -147,6 +147,12 @@ export interface DeployConfig {
    * @default false
    */
   silent?: boolean;
+
+  /**
+   * Force spawning a new process without checking for existing ones.
+   * @default false
+   */
+  forceSpawn?: boolean;
 }
 
 export type Config = Record<ConfigName, DeployConfig>;


### PR DESCRIPTION
The --force-spawn flag allows bypassing the existing process check and forces creation of a new process. This gives users more control over process spawning behavior when needed.

Specifically, my use case is that I'll be programmatically spawning many similar processes, and I'd like to leverage ao-deploy for it. I could force a unique name for every deploy, but it seems more straightforward – and possibly more useful to future users – to be able to bypass the process check altogether.

- Add --force-spawn CLI option
- Implement force spawn logic in DeploymentsManager
- Add documentation in README.md
