### PR TITLE
Fix case where wallet is valid JWK object

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -12,6 +12,7 @@ import {
   isUrl,
   jsonStringify
 } from "./utils";
+import { Wallet } from "./wallet";
 
 const __filename = fileURLToPath(import.meta.url);
 const jiti = createJITI(__filename);
@@ -126,7 +127,6 @@ export class ConfigManager {
       "name",
       "configName",
       "luaPath",
-      "wallet",
       "outDir"
     ];
     const optionalBooleanProps: (keyof DeployConfig)[] = [
@@ -162,6 +162,17 @@ export class ConfigManager {
         );
       }
     });
+
+    // Special handling for wallet which can be either a string or a JWK
+    if (
+      deployConfig.wallet &&
+      !this.#isString(deployConfig.wallet) &&
+      !Wallet.isJwk(deployConfig.wallet)
+    ) {
+      throw new Error(
+        `Invalid "wallet" value in configuration for "${keyName}": ${jsonStringify(deployConfig.wallet)}`
+      );
+    }
   }
 
   static isValidConfig(config: Config): boolean {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
+import Arweave from "arweave";
+import { assert, describe, expect, it } from "vitest";
 import { ConfigManager } from "../src/lib/config";
+import { Wallet } from "../src/lib/wallet";
 
 describe("ConfigManager", () => {
   it("should validate a correct config", () => {
@@ -8,6 +10,21 @@ describe("ConfigManager", () => {
         name: "test-contract",
         contractPath: "contract.lua",
         wallet: "./wallet.json"
+      }
+    };
+    expect(() => ConfigManager.isValidConfig(validConfig)).not.toThrow();
+  });
+
+  it("should validate with a wallet JWK", async () => {
+    const arweave = Arweave.init({});
+    const jwk = await arweave.wallets.generate();
+    assert(Wallet.isJwk(jwk));
+
+    const validConfig = {
+      test: {
+        name: "test-contract",
+        contractPath: "contract.lua",
+        wallet: jwk
       }
     };
     expect(() => ConfigManager.isValidConfig(validConfig)).not.toThrow();


### PR DESCRIPTION
While the `wallet` key is typed as a `string` (path) or `JWKInterface`, unfortunately `ConfigManager.isValidConfig` is stricter and requires a string. 

This PR adds a test where a `JWKInterface` object is provided, and fixes the implementation to make the test pass.