### PR TITLE
feat: hyperbeam mainnet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Options:
   -l, --lua-path [luaPath]      Specify the Lua modules path seperated by semicolon.
   -d, --deploy [deploy]         List of deployment configuration names, separated by commas.
   -b, --build [build]           List of deployment configuration names, separated by commas.
-  -s, --scheduler [scheduler]   Scheduler to be used for the process. (default: "_GQ33BkPtZrqxA84vM8Zk-N2aO0toNNu_C-l-rawrBA")
+  -s, --scheduler [scheduler]   Scheduler to be used for the process.
   -m, --module [module]         Module source for spawning the process.
   -c, --cron [interval]         Cron interval for the process (e.g. 1-minute, 5-minutes).
   -t, --tags [tags...]          Additional tags for spawning the process.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 A package for deploying AO contracts with support for both Node.js and web environments.
 
 > [!Important]
-> **Mainnet is now the default!** Starting from the latest version, `ao-deploy` uses the **mainnet** network powered by Hyperbeam by default. If you need to deploy to the legacy network, use the `--network legacy` flag or set `network: "legacy"` in your configuration.
+> **Mainnet is now the default!** Starting from the latest version, `ao-deploy` uses the **mainnet** network powered by Hyperbeam by default. If you need to deploy to the legacy network, use the `--network legacy`, `--legacy` flag or set `network: "legacy"` in your configuration.
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Options:
   --blueprints [blueprints...]  Blueprints to use for the contract.
   --force-spawn                 Force spawning a new process without checking for existing ones. (default: false)
   --network [network]           Network to use for deployment. (choices: "mainnet", "legacy", default: "mainnet")
+  --legacy                      Deploy to legacy network. (default: false)
   -h, --help                    display help for command
 ```
 
@@ -187,6 +188,12 @@ To deploy to the legacy AO network:
 
 ```sh
 ao-deploy process.lua -n tictactoe -w wallet.json --network legacy
+```
+
+Or use the `--legacy` flag:
+
+```sh
+ao-deploy process.lua -n tictactoe -w wallet.json --legacy
 ```
 
 ##### Custom Hyperbeam Node

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Options:
   -s, --scheduler [scheduler]   Scheduler to be used for the process.
   -m, --module [module]         Module source for spawning the process.
   -c, --cron [interval]         Cron interval for the process (e.g. 1-minute, 5-minutes).
+  --cron-action [cronAction]    Cron tag action for the process. (default: "Cron")
   -t, --tags [tags...]          Additional tags for spawning the process.
   -p, --process-id [processId]  Specify process Id of existing process.
   --build-only                  Bundle the contract into a single file and store it in the process-dist directory.
@@ -607,6 +608,7 @@ The `deployContract` function accepts the following parameters within the Deploy
 - `scheduler` (optional): The scheduler to use for the process. Defaults to `n_XZJhUnmldNFo4dhajoPZWhBXuJk-OcQr5JQ49c4Zo` for mainnet and `_GQ33BkPtZrqxA84vM8Zk-N2aO0toNNu_C-l-rawrBA` for legacy.
 - `tags` (optional): Additional tags to use for spawning the process.
 - `cron` (optional): The cron interval for the process, e.g., "1-minute", "5-minutes". Use format `interval-(second, seconds, minute, minutes, hour, hours, day, days, month, months, year, years, block, blocks, Second, Seconds, Minute, Minutes, Hour, Hours, Day, Days, Month, Months, Year, Years, Block, Blocks)`
+- `cronAction` (optional): The cron tag action to use for the process. Defaults to "Cron".
 - `retry` (optional): Retry options with `count` and `delay` properties. By default, it will retry up to `3` times with a `1000` milliseconds delay between attempts.
 - `processId` (optional): The process id of existing process.
 - `minify` (optional): Reduce the size of the contract before deployment.

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "fmt:check": "prettier --check ."
   },
   "dependencies": {
-    "@permaweb/aoconnect": "^0.0.90",
+    "@permaweb/aoconnect": "^0.0.93",
     "arweave": "^1.15.7",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@permaweb/aoconnect':
-        specifier: ^0.0.90
-        version: 0.0.90
+        specifier: ^0.0.93
+        version: 0.0.93
       arweave:
         specifier: ^1.15.7
         version: 1.15.7
@@ -1961,6 +1961,21 @@ packages:
       fastq: 1.19.1
     dev: true
 
+  /@permaweb/ao-core-libs@0.0.8(debug@4.4.1):
+    resolution: {integrity: sha512-td6JVLn/+jlqwPcxmmagYCdle3tEFSa2MDgughGmLRbc7fQ45e5qZkltjHu09Lqr6o5jXWdUEuEnkUbT1zhi6Q==}
+    dependencies:
+      '@dha-team/arbundles': 1.0.4
+      axios: 1.13.2(debug@4.4.1)
+      constants-browserify: 1.0.0
+      http-message-signatures: 1.0.4
+      structured-headers: 2.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+    dev: false
+
   /@permaweb/ao-loader@0.0.44:
     resolution: {integrity: sha512-O/5XuwqxCD9dTIN/jZ6x4rmqIA/Css0bqaXScOrXc0xTz7VjYseM+PNXFf8vAXiOgnNFmrZzDJ0or94cjmqhZA==}
     engines: {node: '>=18'}
@@ -2019,11 +2034,12 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@permaweb/aoconnect@0.0.90:
-    resolution: {integrity: sha512-VKEkwKV5Lv6q2pai38gz/ngcRML4iApWsJc5B8X8ow9fJIXnd9UK8y0HMbrKUF/VB5Eb8r8lJhDr76yiL6QWAA==}
+  /@permaweb/aoconnect@0.0.93:
+    resolution: {integrity: sha512-IWHOIC2qcLMNcg4XbW9kdE246EiyCt1tnVkjJbr7/lzBr7oKiQXxnxY8GihaVnQp+qeKSfZWhUzge7f9yM+01Q==}
     engines: {node: '>=18'}
     dependencies:
       '@dha-team/arbundles': 1.0.3
+      '@permaweb/ao-core-libs': 0.0.8(debug@4.4.1)
       '@permaweb/ao-scheduler-utils': 0.0.25
       '@permaweb/protocol-tag-utils': 0.0.2
       axios: 1.8.3(debug@4.4.1)
@@ -2868,6 +2884,16 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
+  /axios@1.13.2(debug@4.4.1):
+    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
+    dependencies:
+      follow-redirects: 1.15.9(debug@4.4.1)
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /axios@1.8.3:
     resolution: {integrity: sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==}
     dependencies:
@@ -3318,6 +3344,10 @@ packages:
     resolution: {integrity: sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==}
     engines: {node: ^14.18.0 || >=16.10.0}
     dev: true
+
+  /constants-browserify@1.0.0:
+    resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
+    dev: false
 
   /content-disposition@1.0.0:
     resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
@@ -4359,6 +4389,17 @@ packages:
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
       mime-types: 2.1.35
+
+  /form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+    dev: false
 
   /formidable@1.2.6:
     resolution: {integrity: sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -360,6 +360,9 @@ async function buildHandler() {
     } else {
       await deploymentHandler();
     }
+
+    // Explicitly exit after successful completion to ensure all handles are closed
+    process.exit(0);
   } catch (error: any) {
     const logger = Logger.init(packageJson.name);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,7 +47,7 @@ function getPackageJson() {
 }
 
 function logDeploymentDetails(result: DeployResult) {
-  const { messageId, processId, isNewProcess, configName } = result;
+  const { messageId, processId, isNewProcess, configName, network } = result;
   const processUrl = chalk.green(`${aoExplorerUrl}/#/entity/${processId}`);
   const logger = Logger.init(configName);
 
@@ -56,7 +56,11 @@ function logDeploymentDetails(result: DeployResult) {
   }
   if (messageId) {
     const messageUrl = chalk.green(`${aoExplorerUrl}/#/message/${messageId}`);
-    logger.log(`Deployment Message: ${messageUrl}`);
+    if (network === "legacy") {
+      logger.log(`Deployment Message: ${messageUrl}`);
+    } else {
+      logger.log(`Deployment Slot: ${messageId}`);
+    }
   }
 }
 
@@ -115,6 +119,11 @@ program
   .option(
     "-c, --cron [interval]",
     "Cron interval for the process (e.g. 1-minute, 5-minutes)."
+  )
+  .option(
+    "--cron-action [cronAction]",
+    "Cron tag action for the process.",
+    "Cron"
   )
   .option("-t, --tags [tags...]", "Additional tags for spawning the process.")
   .option(
@@ -218,6 +227,7 @@ async function deploymentHandler() {
         scheduler: options.scheduler,
         module: options.module,
         cron: options.cron,
+        cronAction: options.cronAction,
         tags,
         retry: {
           count: parseToInt(options.retryCount, 3),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,15 +52,13 @@ function logDeploymentDetails(result: DeployResult) {
   const logger = Logger.init(configName);
 
   if (isNewProcess) {
-    logger.log(`Deployed Process: ${processUrl}`);
+    logger.log(`✨ New process deployed: ${processUrl}`);
+  } else {
+    logger.log(`🔄 Existing process updated: ${processUrl}`);
   }
-  if (messageId) {
+  if (messageId && network === "legacy") {
     const messageUrl = chalk.green(`${aoExplorerUrl}/#/message/${messageId}`);
-    if (network === "legacy") {
-      logger.log(`Deployment Message: ${messageUrl}`);
-    } else {
-      logger.log(`Deployment Slot: ${messageId}`);
-    }
+    logger.log(`📨 Deployment message: ${messageUrl}`);
   }
 }
 
@@ -188,6 +186,7 @@ program
     "--force-spawn",
     "Force spawning a new process without checking for existing ones."
   )
+  .option("--legacy", "Deploy to legacy network.")
   .addOption(
     new Option("--network [network]", "Network to use for deployment.")
       .choices(["mainnet", "legacy"])
@@ -251,7 +250,7 @@ async function deploymentHandler() {
           browser: options.browser,
           browserProfile: options.browserProfile
         },
-        network: options.network
+        network: options.legacy ? "legacy" : options.network
       });
       logDeploymentDetails(result);
     } else {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -109,8 +109,7 @@ program
   )
   .option(
     "-s, --scheduler [scheduler]",
-    "Scheduler to be used for the process.",
-    "_GQ33BkPtZrqxA84vM8Zk-N2aO0toNNu_C-l-rawrBA"
+    "Scheduler to be used for the process."
   )
   .option("-m, --module [module]", "Module source for spawning the process.")
   .option(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import chalk from "chalk";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import fs from "node:fs";
 import path from "node:path";
 import process, { emitWarning } from "node:process";
@@ -149,6 +149,12 @@ program
     "https://mu.ao-testnet.xyz"
   )
   .option(
+    "--hb-url [url]",
+    "Hyperbeam Node URL to connect to.",
+    parseUrl,
+    "https://push.forward.computer"
+  )
+  .option(
     "--concurrency [limit]",
     "Concurrency limit for deploying multiple processes.",
     parseToInt,
@@ -173,6 +179,11 @@ program
   .option(
     "--force-spawn",
     "Force spawning a new process without checking for existing ones."
+  )
+  .addOption(
+    new Option("--network [network]", "Network to use for deployment.")
+      .choices(["mainnet", "legacy"])
+      .default("mainnet")
   );
 
 program.parse(process.argv);
@@ -220,7 +231,8 @@ async function deploymentHandler() {
         services: {
           gatewayUrl: options.gatewayUrl,
           cuUrl: options.cuUrl,
-          muUrl: options.muUrl
+          muUrl: options.muUrl,
+          hbUrl: options.hbUrl
         },
         minify: options.minify,
         onBoot: options.onBoot,
@@ -229,7 +241,8 @@ async function deploymentHandler() {
         browserConfig: {
           browser: options.browser,
           browserProfile: options.browserProfile
-        }
+        },
+        network: options.network
       });
       logDeploymentDetails(result);
     } else {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -103,7 +103,8 @@ export class ConfigManager {
       (typeof services === "object" &&
         (services.gatewayUrl === undefined || isUrl(services?.gatewayUrl)) &&
         (services.cuUrl === undefined || isUrl(services?.cuUrl)) &&
-        (services.muUrl === undefined || isUrl(services?.muUrl)));
+        (services.muUrl === undefined || isUrl(services?.muUrl)) &&
+        (services.hbUrl === undefined || isUrl(services?.hbUrl)));
 
     if (!isValid) {
       throw new Error(
@@ -208,6 +209,19 @@ export class ConfigManager {
     return true;
   }
 
+  static #validateNetwork(
+    network: DeployConfig["network"],
+    keyName: string
+  ): boolean {
+    if (network && network !== "mainnet" && network !== "legacy") {
+      throw new Error(
+        `Invalid "network" value in configuration for "${keyName}": ${jsonStringify(network)}`
+      );
+    }
+
+    return true;
+  }
+
   static isValidConfig(config: Config): boolean {
     // Check if config exists, is an object, and is not empty
     if (
@@ -256,6 +270,7 @@ export class ConfigManager {
       this.#validateRetry(deployConfig.retry, name);
       this.#validateServices(deployConfig.services, name);
       this.#validateBrowserConfig(deployConfig.browserConfig, name);
+      this.#validateNetwork(deployConfig.network, name);
 
       if (deployConfig.cron && !isCronPattern(deployConfig.cron)) {
         throw new Error(

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -22,6 +22,10 @@ export const AOS_QUERY = `query ($owners: [String!]!, $names: [String!]!) {
       edges {
         node {
           id
+          tags {
+            name
+            value
+          }
         }
       }
     }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,10 +3,11 @@ export const APP_NAME = "ao-deploy";
 export const defaultServices = {
   gatewayUrl: "https://arweave.net",
   cuUrl: "https://cu.ao-testnet.xyz",
-  muUrl: "https://mu.ao-testnet.xyz"
+  muUrl: "https://mu.ao-testnet.xyz",
+  hbUrl: "https://push.forward.computer"
 };
 
-export const aoExplorerUrl = "https://www.ao.link";
+export const aoExplorerUrl = "https://aolink.arweave.net";
 
 export const AOS_QUERY = `query ($owners: [String!]!, $names: [String!]!) {
     transactions(

--- a/src/lib/deploy/deploy.common.ts
+++ b/src/lib/deploy/deploy.common.ts
@@ -330,6 +330,9 @@ export class BaseDeploymentsManager {
       });
 
       if (onBoot) {
+        if (!isSharedWallet) {
+          await walletInstance.close("success");
+        }
         return { name, processId, isNewProcess, configName };
       }
     }

--- a/src/lib/deploy/deploy.common.ts
+++ b/src/lib/deploy/deploy.common.ts
@@ -175,6 +175,7 @@ export class BaseDeploymentsManager {
     getContractSource,
     tags,
     cron,
+    cronAction,
     module,
     scheduler,
     retry,
@@ -301,7 +302,7 @@ export class BaseDeploymentsManager {
         tags = [
           ...tags,
           { name: "Cron-Interval", value: cron },
-          { name: "Cron-Tag-Action", value: "Cron" }
+          { name: "Cron-Tag-Action", value: cronAction || "Cron" }
         ];
       }
 
@@ -333,7 +334,7 @@ export class BaseDeploymentsManager {
         if (!isSharedWallet) {
           await walletInstance.close("success");
         }
-        return { name, processId, isNewProcess, configName };
+        return { name, processId, isNewProcess, configName, network };
       }
     }
 
@@ -392,7 +393,8 @@ export class BaseDeploymentsManager {
       processId: processId!,
       messageId: messageId!,
       isNewProcess,
-      configName
+      configName,
+      network
     };
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,6 +25,12 @@ export interface Services {
    * @default "https://mu.ao-testnet.xyz"
    */
   muUrl?: string;
+
+  /**
+   * Hyperbeam URL to use for deployment
+   * @default "https://push.forward.computer"
+   */
+  hbUrl?: string;
 }
 
 export type DeployConfig = {
@@ -47,7 +53,8 @@ export type DeployConfig = {
 
   /**
    * Scheduler to use for Process
-   * @default "_GQ33BkPtZrqxA84vM8Zk-N2aO0toNNu_C-l-rawrBA"
+   * @default "_GQ33BkPtZrqxA84vM8Zk-N2aO0toNNu_C-l-rawrBA" for legacy
+   * @default "n_XZJhUnmldNFo4dhajoPZWhBXuJk-OcQr5JQ49c4Zo" for mainnet
    */
   scheduler?: string;
 
@@ -113,6 +120,12 @@ export type DeployConfig = {
    * @default false
    */
   minify?: boolean;
+
+  /**
+   * Network to use for deployment
+   * @default "mainnet"
+   */
+  network?: "mainnet" | "legacy";
 
   /**
    * Custom function to transform contract code before deployment

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -71,6 +71,12 @@ export type DeployConfig = {
   cron?: string;
 
   /**
+   * Cron tag action to use for Process i.e (Cron, Once)
+   * @default "Cron-Tick"
+   */
+  cronAction?: string;
+
+  /**
    * Wallet path, JWK itself, or "browser" to use browser wallet (Wander or other compatible wallet)
    */
   wallet?: JWKInterface | "browser" | (string & {});
@@ -236,6 +242,7 @@ export interface DeployResult {
   messageId?: string;
   processId: string;
   isNewProcess: boolean;
+  network: Network;
 }
 
 export interface BundleResult {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,8 @@ export interface Tag {
   value: string;
 }
 
+export type Network = "mainnet" | "legacy";
+
 export interface Services {
   /**
    * The URL of the desired Gateway.
@@ -125,7 +127,7 @@ export type DeployConfig = {
    * Network to use for deployment
    * @default "mainnet"
    */
-  network?: "mainnet" | "legacy";
+  network?: Network;
 
   /**
    * Custom function to transform contract code before deployment

--- a/test/deploy.test.ts
+++ b/test/deploy.test.ts
@@ -4,7 +4,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 import { GQL } from "wao";
 import { deployContract, deployContracts } from "../src/lib/deploy/deploy.node";
 import { isArweaveAddress } from "../src/lib/utils/utils.common";
-import type { Services } from "../src/types";
+import type { Blueprint, Services } from "../src/types";
 
 const services: Services = {
   cuUrl: "http://localhost:4004",
@@ -38,6 +38,7 @@ describe("deploy", () => {
         wallet,
         blueprints: ["token"],
         services,
+        network: "legacy",
         silent: true
       });
 
@@ -59,6 +60,7 @@ describe("deploy", () => {
         wallet,
         contractPath: "test/fixtures/sample.lua",
         services,
+        network: "legacy",
         silent: true
       });
 
@@ -81,6 +83,7 @@ describe("deploy", () => {
         contractPath: "test/fixtures/sample.lua",
         blueprints: ["token"],
         services,
+        network: "legacy",
         silent: true
       });
 
@@ -93,7 +96,7 @@ describe("deploy", () => {
         deployContract({
           name: "test-invalid",
           // Use empty array to trigger validation failure while satisfying type check
-          blueprints: [] as unknown as import("../src/types").Blueprint[]
+          blueprints: [] as unknown as Blueprint[]
         })
       ).rejects.toThrow();
     });
@@ -107,6 +110,7 @@ describe("deploy", () => {
         blueprints: ["token"],
         cron: "5-minutes",
         services,
+        network: "legacy",
         silent: true
       });
 
@@ -137,6 +141,7 @@ describe("deploy", () => {
         contractPath: "test/fixtures/sample.lua",
         minify: true,
         services,
+        network: "legacy",
         silent: true
       });
 
@@ -151,6 +156,7 @@ describe("deploy", () => {
         blueprints: ["token"],
         scheduler: "_GQ33BkPtZrqxA84vM8Zk-N2aO0toNNu_C-l-rawrBA",
         services,
+        network: "legacy",
         silent: true
       });
 
@@ -170,6 +176,7 @@ describe("deploy", () => {
         blueprints: ["token"],
         tags: customTags,
         services,
+        network: "legacy",
         silent: true
       });
 
@@ -192,6 +199,7 @@ describe("deploy", () => {
         blueprints: ["token"],
         onBoot: true,
         services,
+        network: "legacy",
         silent: true
       });
 
@@ -233,6 +241,7 @@ describe("deploy", () => {
         wallet,
         blueprints: ["token"],
         services,
+        network: "legacy",
         silent: true
       });
 
@@ -243,6 +252,7 @@ describe("deploy", () => {
         blueprints: ["token"],
         processId: initial.processId,
         services,
+        network: "legacy",
         silent: true
       });
 
@@ -263,6 +273,7 @@ describe("deploy", () => {
         wallet,
         blueprints: ["token"],
         services,
+        network: "legacy",
         silent: true
       });
 
@@ -273,6 +284,7 @@ describe("deploy", () => {
         blueprints: ["token"],
         forceSpawn: true,
         services,
+        network: "legacy",
         silent: true
       });
 
@@ -287,10 +299,9 @@ describe("deploy", () => {
         deployContract({
           name: "test-invalid",
           wallet,
-          blueprints: [
-            "invalid-blueprint" as unknown as import("../src/types").Blueprint
-          ],
+          blueprints: ["invalid-blueprint" as unknown as Blueprint],
           services,
+          network: "legacy",
           silent: true
         })
       ).rejects.toThrow();
@@ -303,6 +314,7 @@ describe("deploy", () => {
           wallet,
           contractPath: "invalid/path.lua",
           services,
+          network: "legacy",
           silent: true
         })
       ).rejects.toThrow();
@@ -318,6 +330,7 @@ describe("deploy", () => {
         contractPath: "test/fixtures/sample.lua",
         contractTransformer: (source) => `${transformComment}\n${source}`,
         services,
+        network: "legacy",
         silent: true
       });
 
@@ -337,6 +350,7 @@ describe("deploy", () => {
         contractPath: "test/fixtures/sample.lua",
         minify: true,
         services,
+        network: "legacy",
         silent: true
       });
 
@@ -364,6 +378,7 @@ describe("deploy", () => {
             delay: 3000
           },
           services,
+          network: "legacy" as const,
           silent: true
         },
         {
@@ -376,6 +391,7 @@ describe("deploy", () => {
             delay: 3000
           },
           services,
+          network: "legacy" as const,
           silent: true
         }
       ];
@@ -418,6 +434,7 @@ describe("deploy", () => {
           wallet,
           contractPath: "test/fixtures/sample.lua",
           services,
+          network: "legacy" as const,
           silent: true
         },
         {
@@ -425,6 +442,7 @@ describe("deploy", () => {
           wallet,
           contractPath: "invalid/path.lua", // Invalid path
           services,
+          network: "legacy" as const,
           silent: true
         }
       ];


### PR DESCRIPTION
## Summary
Adds Hyperbeam mainnet support and makes it the default deployment network, with legacy network still available as an option.

## Changes
- **Network Support**: Added `--network` flag with `mainnet` (default) and `legacy` options
- **Hyperbeam Integration**: Mainnet mode uses Hyperbeam node for improved performance
  - Default Hyperbeam URL: `https://push.forward.computer`
  - Configurable via `--hb-url` CLI flag or `services.hbUrl` API parameter
  - Dynamic authority address fetching from Hyperbeam node
- **Network-specific Schedulers**:
  - Mainnet: `n_XZJhUnmldNFo4dhajoPZWhBXuJk-OcQr5JQ49c4Zo`
  - Legacy: `_GQ33BkPtZrqxA84vM8Zk-N2aO0toNNu_C-l-rawrBA`
- **Documentation**: Comprehensive README updates with examples and migration guide

## Breaking Changes
⚠️ **Default network changed from legacy to mainnet**

### Migration
To continue using the legacy network:
- CLI: Add `--network legacy` flag
- API: Add `network: "legacy"` to config
- Config file: Set `network: "legacy"` in deployment config

## Backward Compatibility
Legacy network remains fully supported. No code changes required if explicitly specifying `network: "legacy"`.